### PR TITLE
Separated html/javascript of FB button and changed url associated with popup to be relative to each post

### DIFF
--- a/website/theses/templates/theses/conversion.html
+++ b/website/theses/templates/theses/conversion.html
@@ -17,6 +17,10 @@
         </h3>
     </a>
 
+    <!-- Facebook Share Button -->
+    <div id="fb-root"></div>
+    <div class="fb-share-button mt-1 mb-2" data-href="{{ origin_url }}" data-layout="button" data-size="large" data-mobile-iframe="true"><a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{ origin_url }}&title=My new thesis topic! {{ title }}" class="fb-xfbml-parse-ignore">Share</a></div>
+
     <p>
         Take me <a href="{{ origin_url }}">back</a>
     </p>
@@ -25,8 +29,7 @@
 
 
 {% block extra_js_2 %}
-    <!-- Facebook Share Button -->
-    <div id="fb-root"></div>
+    <!-- Script for Facebook Share Button -->
     <script>(function(d, s, id) {
     var js, fjs = d.getElementsByTagName(s)[0];
         if (d.getElementById(id)) return;
@@ -34,5 +37,4 @@
         js.src = 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.12';
         fjs.parentNode.insertBefore(js, fjs);
     }(document, 'script', 'facebook-jssdk'));</script>
-    <div class="fb-share-button mt-1 mb-2" data-href="http://effectivethesis.com/humanitys-impact-wild-animal-suffering/" data-layout="button" data-size="large" data-mobile-iframe="true"><a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{ origin_url }}&title=My new thesis topic! {{ title }}" class="fb-xfbml-parse-ignore">Share</a></div>
 {% endblock %}


### PR DESCRIPTION
- In the last update there was a problem with the button not appearing in the right place. Made changes to keep the script and html in separate blocks to fix.
- There was also an issue where in the popup's description (after clicking on share button) it kept pointing to one specific topic. The description should now be associated with the `{{ original url }}` and change relative to the specific topic the user clicked the share button on.