### PR TITLE
Centered images in /how-choose-thesis/ section

### DIFF
--- a/website/eacr/static/css/theses.css
+++ b/website/eacr/static/css/theses.css
@@ -102,6 +102,8 @@ h1 h2 {
 .rich-text img {
     max-width: 100%;
     height: auto;
+    display: block;
+    margin: auto;
 }
 
 .block-image img {


### PR DESCRIPTION
Added two additional properties to `.rich-text img` class in `theses.css` to center images.

**BEFORE:**
![image](https://user-images.githubusercontent.com/25831028/37561783-e8966228-2a2d-11e8-9bfa-d441ba8703fb.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/25831028/37561784-efaa4d86-2a2d-11e8-9366-4be839046055.png)
