### PR TITLE
Adding effectivethesis.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# effectivethesis.com
+# effectivethesis.org
 
-This is a repository for a website of effectivethesis.com
+This is a repository for a website of effectivethesis.org
 
 # Development
 Use `docker-compose`:

--- a/bin/init-letsencrypt.sh
+++ b/bin/init-letsencrypt.sh
@@ -19,7 +19,7 @@ if ! [ -x "$(command -v $docker_compose)" ]; then
   exit 1
 fi
 
-domains=(effectivethesis.com)
+domains=(effectivethesis.org)
 rsa_key_size=4096
 data_path="./data/certbot"
 email="martin.racak@gmail.com" # Adding a valid address is strongly recommended

--- a/bin/nginx.conf
+++ b/bin/nginx.conf
@@ -10,7 +10,19 @@ server {
 
 server {
     listen 80;
-    server_name ${ENV_PREFIX}effectivethesis.com;
+    server_name effectivethesis.com;
+    return 301 $scheme://effectivethesis.org$request_uri;
+}
+
+server {
+    listen 80;
+    server_name www.effectivethesis.org;
+    return 301 $scheme://effectivethesis.org$request_uri;
+}
+
+server {
+    listen 80;
+    server_name ${ENV_PREFIX}effectivethesis.org;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;
@@ -24,7 +36,7 @@ server {
 # now we declare our main server
 server {
     listen 443 ssl;
-    server_name ${ENV_PREFIX}effectivethesis.com localhost;
+    server_name ${ENV_PREFIX}effectivethesis.org localhost;
     client_max_body_size 4G;
 
     ssl_certificate /etc/letsencrypt/live/${ENV_PREFIX}effectivethesis.com/fullchain.pem;

--- a/bin/nginx.conf
+++ b/bin/nginx.conf
@@ -5,7 +5,7 @@ upstream main_server {
 server {
     listen 80;
     server_name www.effectivethesis.com;
-    return 301 $scheme://effectivethesis.com$request_uri;
+    return 301 $scheme://effectivethesis.org$request_uri;
 }
 
 server {
@@ -39,8 +39,8 @@ server {
     server_name ${ENV_PREFIX}effectivethesis.org localhost;
     client_max_body_size 4G;
 
-    ssl_certificate /etc/letsencrypt/live/${ENV_PREFIX}effectivethesis.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/${ENV_PREFIX}effectivethesis.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/${ENV_PREFIX}effectivethesis.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${ENV_PREFIX}effectivethesis.org/privkey.pem;
 
     # SSL HTTPS config provided by Let's Encrypt
     include /etc/letsencrypt/options-ssl-nginx.conf;

--- a/website/theses/templates/theses/thesis_page.html
+++ b/website/theses/templates/theses/thesis_page.html
@@ -51,13 +51,13 @@
                 <p>
                     You may also consider: Is this topic a good fit for
                     your longer term goals?
-                    <a href="http://effectivethesis.com/how-choose-thesis/">Check this advice</a>.
+                    <a href="https://effectivethesis.org/how-choose-thesis/">Check this advice</a>.
                 </p>
                 <p>
                     Want to help with designing the topic to better fit
                     your skills, supervisor availability, longer
                     term career goals and other circumstances?
-                    <a href="http://effectivethesis.com/thesis-coaching/">Apply for a Thesis Topic Coaching</a>!
+                    <a href="https://effectivethesis.org/thesis-coaching/">Apply for a Thesis Topic Coaching</a>!
                 </p>
 
                 <form id="contact-form" action="" method="POST">


### PR DESCRIPTION
This is a request to use effectivethesis.org instead of effectivethesis.com.

TODO:
- [ ] solve SSL/certificates

The [beta.]effectivethesis.org targets the same IPs as the old one:
![image](https://user-images.githubusercontent.com/2741256/79113523-66f7f200-7d81-11ea-8921-7f458a895a12.png)


effectivethesis.com
![image](https://user-images.githubusercontent.com/2741256/79113558-75460e00-7d81-11ea-935a-4d244c2cc1f5.png)

