### PR TITLE
Prepare for Hetzner migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,10 @@ jobs:
           name: Deploy Over SSH
           command: |
             ssh -o "StrictHostKeyChecking=no" dan@35.207.130.87 "env ENVIRONMENT=beta IMAGE_TAG=$CIRCLE_SHA1 sh /var/server/efektivnialtruismus.cz/bin/deploy.sh"
+      - run:
+          name: Deploy Over SSH Hetzner
+          command: |
+            ssh -o "StrictHostKeyChecking=no" dan@159.69.217.7 "env ENVIRONMENT=beta IMAGE_TAG=$CIRCLE_SHA1 sh /var/server/efektivnialtruismus.cz/bin/deploy.sh"
   deployme-production-master:
     docker:
       - image: circleci/buildpack-deps:stretch
@@ -36,6 +40,10 @@ jobs:
           name: Deploy Over SSH
           command: |
             ssh -o "StrictHostKeyChecking=no" dan@35.207.162.44 "env ENVIRONMENT=master IMAGE_TAG=$CIRCLE_SHA1 sh /var/server/efektivnialtruismus.cz/bin/deploy.sh"
+      - run:
+          name: Deploy Over SSH Hetzner
+          command: |
+            ssh -o "StrictHostKeyChecking=no" dan@135.181.30.65 "env ENVIRONMENT=master IMAGE_TAG=$CIRCLE_SHA1 sh /var/server/efektivnialtruismus.cz/bin/deploy.sh"
 workflows:
   version: 2
   build-n-deploy:

--- a/bin/ansible/hosts.ini
+++ b/bin/ansible/hosts.ini
@@ -1,0 +1,6 @@
+[webservers]
+135.181.30.65 env=master ansible_user=dan
+159.69.217.7  env=beta   ansible_user=dan
+
+[all:vars]
+

--- a/bin/ansible/main.yaml
+++ b/bin/ansible/main.yaml
@@ -1,0 +1,84 @@
+- name: Bootstrap and install base tools
+  hosts: all
+  vars_files: [ vars.yaml ]
+  become: true
+  tasks:
+  - name: Ping the node
+    ping:
+
+  - name: Set locale
+    locale_gen:
+      name: en_US.UTF-8
+      state: present
+
+  - name: Set timezone variables
+    copy: content='Europe/Prague'
+          dest=/etc/timezone
+          owner=root
+          group=root
+          mode=0644
+          backup=yes
+    notify:
+      - update timezone
+
+  - name: Install default tools
+    apt:
+      pkg: [sudo, vim, htop, iotop, curl, git]
+      state: present
+      update_cache: yes
+
+  handlers:
+  - name: update timezone
+    command: dpkg-reconfigure --frontend noninteractive tzdata
+
+
+- name: Set up Docker
+  hosts: webservers
+  vars_files: [ vars.yaml ]
+  become: true
+  roles:
+    - geerlingguy.pip
+    - geerlingguy.docker
+
+
+- name: Set up cluster
+  hosts: webservers
+  vars_files: [ vars.yaml ]
+  become: true
+  tasks:
+    - name: Check if we have the repo already
+      stat:
+        path: /var/server/efektivnialtruismus.cz
+      register: git
+
+    - name: Get the Git repo
+      git:
+        repo: 'https://github.com/ea-czech-republic/efektivnialtruismus.cz'
+        dest: /var/server/efektivnialtruismus.cz
+      when: not git.stat.isdir is defined or not git.stat.isdir
+
+    - name: Check if we have certificates already
+      stat:
+        path: /var/server/efektivnialtruismus.cz/data/certbot/conf/live/
+      register: cert
+
+    - name: Set up dummy certificates
+      shell: /var/server/efektivnialtruismus.cz/bin/init-letsencrypt-dummy.sh
+      environment:
+        ENVIRONMENT: "{{env}}"
+        IMAGE_TAG: latest
+      when: not cert.stat.isdir is defined or not cert.stat.isdir
+
+    - name: Run deploy
+      shell: /var/server/efektivnialtruismus.cz/bin/deploy.sh
+      environment:
+        ENVIRONMENT: "{{env}}"
+        IMAGE_TAG: latest
+      when: not cert.stat.isdir is defined or not cert.stat.isdir
+
+    - name: Set up proper certificates
+      shell: /var/server/efektivnialtruismus.cz/bin/init-letsencrypt.sh
+      environment:
+        ENVIRONMENT: "{{env}}"
+        IMAGE_TAG: latest
+      when: not cert.stat.isdir is defined or not cert.stat.isdir

--- a/bin/ansible/main.yaml
+++ b/bin/ansible/main.yaml
@@ -57,6 +57,19 @@
         dest: /var/server/efektivnialtruismus.cz
       when: not git.stat.isdir is defined or not git.stat.isdir
 
+
+    - name: Check if we have the environment file
+      stat:
+        path: "/var/server/efektivnialtruismus.cz/bin/{{env}}.env"
+      register: env
+
+    - name: Touch the env file
+      file:
+        path: "/var/server/efektivnialtruismus.cz/bin/{{env}}.env"
+        state: touch
+      when: not env.stat.isfile is defined or not env.stat.isfile
+
+
     - name: Check if we have certificates already
       stat:
         path: /var/server/efektivnialtruismus.cz/data/certbot/conf/live/

--- a/bin/ansible/requirements.yaml
+++ b/bin/ansible/requirements.yaml
@@ -1,0 +1,2 @@
+- src: geerlingguy.docker
+- src: geerlingguy.pip

--- a/bin/ansible/vars.yaml
+++ b/bin/ansible/vars.yaml
@@ -1,0 +1,13 @@
+docker_package_state: present
+docker_install_compose: true
+docker_compose_path: /usr/local/bin/docker-compose
+docker_service_state: started
+docker_service_enabled: true
+docker_restart_handler_state: restarted
+docker_apt_release_channel: stable
+ansible_python_interpreter: /usr/bin/python3
+
+pip_package: python3-pip
+pip_executable: pip3
+pip_install_packages:
+  - name: docker

--- a/bin/init-letsencrypt-dummy.sh
+++ b/bin/init-letsencrypt-dummy.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+cd /var/server/efektivnialtruismus.cz
+
+# You may need to setup IMAGE_TAG and ENVIRONMENT to make it work
+
+docker_compose="docker run --rm \
+    -e IMAGE_TAG=$IMAGE_TAG \
+    -e ENVIRONMENT=$ENVIRONMENT \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$PWD:$PWD" \
+    -w="$PWD" \
+    docker/compose:1.24.0 \
+    -f docker-compose.yaml \
+    -f dc-deploy.yaml"
+
+if ! [ -x "$(command -v $docker_compose)" ]; then
+  echo 'Error: docker-compose is not available.' >&2
+  exit 1
+fi
+
+domains=(effectivethesis.org effectivethesis.com)
+rsa_key_size=4096
+data_path="./data/certbot"
+email="martin.racak@gmail.com" # Adding a valid address is strongly recommended
+staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+$docker_compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo

--- a/bin/nginx.conf
+++ b/bin/nginx.conf
@@ -52,7 +52,7 @@ server {
 # now we declare our main server
 server {
     listen 443 ssl;
-    server_name ${ENV_PREFIX}effectivethesis.org localhost;
+    server_name ${ENV_PREFIX}effectivethesis.org ${ENV_PREFIX}hetzner.effectivethesis.org  localhost;
     client_max_body_size 4G;
 
     ssl_certificate /etc/letsencrypt/live/${ENV_PREFIX}effectivethesis.org/fullchain.pem;

--- a/bin/run_playbooks.sh
+++ b/bin/run_playbooks.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ansible-galaxy install -r ansible/requirements.yaml
+ansible-playbook -i ansible/hosts.ini ansible/main.yaml


### PR DESCRIPTION
I've prepared CircleCI for temporary parallel deployment to the old and the new servers. DNS is also ready, the new servers are accessible at hetzner.effectivethesis.org a beta.hetzner.effectivethesis.org.

Merging this shouldn't break deployment to the old servers, but should allow us to test the new ones, migrate the DBs, and then switch over by flipping the DNS records (almost instantly, due to using a CDN).